### PR TITLE
fix(core): remove restriction of configuration

### DIFF
--- a/packages/core/src/executors/build/schema.json
+++ b/packages/core/src/executors/build/schema.json
@@ -15,7 +15,6 @@
     },
     "configuration": {
       "type": "string",
-      "enum": ["Debug", "Release"],
       "default": "Debug",
       "description": "Defines the build configuration. The default for most projects is Debug, but you can override the build configuration settings in your project"
     },

--- a/packages/core/src/executors/publish/schema.json
+++ b/packages/core/src/executors/publish/schema.json
@@ -7,7 +7,6 @@
   "properties": {
     "configuration": {
       "type": "string",
-      "enum": ["Debug", "Release"],
       "default": "Debug",
       "description": "Defines the build configuration The default for most projects is Debug, but you can override the build configuration settings in your project."
     },


### PR DESCRIPTION
Prior to this change the schema.jsons for build and publish required
the build configuration to be either Debug or Release. This change
removes that restriction, allowing build configurations with other names
